### PR TITLE
feat(mcp-toolbox): add count-organization-unit-members-with-identifier tool

### DIFF
--- a/mcp-toolbox/tools-auth.yaml
+++ b/mcp-toolbox/tools-auth.yaml
@@ -581,6 +581,58 @@ statement: |
 ---
 
 kind: tool
+name: count-organization-unit-members-with-identifier
+type: neo4j-cypher
+source: crisalid-neo4j
+authRequired:
+  - crisalid-keycloak
+description: |
+  Count and list the direct members of a given OrganizationUnit (by UID) that
+  do — and do not — have an external identifier of a given type (e.g. 'orcid',
+  'idref', 'idhals', 'scopus'). Returns the total member count, the count and
+  percentage of members carrying the identifier, and the full member list for
+  both groups — computed in a single deterministic query. Use this to answer
+  questions such as "what proportion of LS2N researchers have an ORCID?" or
+  "which members of the lab have no IdRef?"; do NOT enumerate members and check
+  their identifiers one by one. Resolve the unit UID first with
+  search-organization-unit-by-name. Only direct members (the MEMBER_OF relation
+  from Person nodes) are considered, not members of child units.
+parameters:
+  - name: organization_unit_uid
+    type: string
+    description: Unique identifier of the OrganizationUnit (OrganizationUnit.uid)
+  - name: identifier_type
+    type: string
+    description: AgentIdentifier type to test for, e.g. orcid, idref, idhals, scopus, hal, openalex, ror, wikidata, isni, viaf
+    default: orcid
+statement: |
+  MATCH (org:OrganizationUnit {uid: $organization_unit_uid})
+  OPTIONAL MATCH (person:Person)-[:MEMBER_OF]->(org)
+  WITH org, collect(DISTINCT person) AS all_members
+  WITH org, [m IN all_members WHERE m IS NOT NULL] AS members
+  WITH org, members,
+    [m IN members WHERE exists(
+      (m)-[:HAS_IDENTIFIER]->(:AgentIdentifier {type: $identifier_type}) )] AS with_id,
+    [m IN members WHERE NOT exists(
+      (m)-[:HAS_IDENTIFIER]->(:AgentIdentifier {type: $identifier_type}) )] AS without_id
+  RETURN
+    org.uid AS organization_unit_uid,
+    $identifier_type AS identifier_type,
+    size(members) AS member_count,
+    size(with_id) AS with_identifier_count,
+    size(without_id) AS without_identifier_count,
+    CASE WHEN size(members) = 0 THEN 0.0
+         ELSE round(100.0 * size(with_id) / size(members), 1) END AS percent_with_identifier,
+    [m IN with_id | {
+      person_uid: m.uid,
+      person_name: m.display_name,
+      identifier_values: [(m)-[:HAS_IDENTIFIER]->(i:AgentIdentifier {type: $identifier_type}) | i.value]
+    }] AS members_with_identifier,
+    [m IN without_id | {person_uid: m.uid, person_name: m.display_name}] AS members_without_identifier
+
+---
+
+kind: tool
 name: publications-by-theme
 type: neo4j-cypher
 source: crisalid-neo4j
@@ -666,6 +718,7 @@ tools:
   - search-researchers-by-concept
   - search-organization-unit-by-name
   - get-organization-unit-members
+  - count-organization-unit-members-with-identifier
   - publications-by-theme
 
 ---
@@ -686,5 +739,6 @@ tools:
   - search-researchers-by-concept
   - search-organization-unit-by-name
   - get-organization-unit-members
+  - count-organization-unit-members-with-identifier
   - publications-by-theme
   - execute-cypher-readonly

--- a/mcp-toolbox/tools.yaml
+++ b/mcp-toolbox/tools.yaml
@@ -551,6 +551,56 @@ statement: |
 ---
 
 kind: tool
+name: count-organization-unit-members-with-identifier
+type: neo4j-cypher
+source: crisalid-neo4j
+description: |
+  Count and list the direct members of a given OrganizationUnit (by UID) that
+  do — and do not — have an external identifier of a given type (e.g. 'orcid',
+  'idref', 'idhals', 'scopus'). Returns the total member count, the count and
+  percentage of members carrying the identifier, and the full member list for
+  both groups — computed in a single deterministic query. Use this to answer
+  questions such as "what proportion of LS2N researchers have an ORCID?" or
+  "which members of the lab have no IdRef?"; do NOT enumerate members and check
+  their identifiers one by one. Resolve the unit UID first with
+  search-organization-unit-by-name. Only direct members (the MEMBER_OF relation
+  from Person nodes) are considered, not members of child units.
+parameters:
+  - name: organization_unit_uid
+    type: string
+    description: Unique identifier of the OrganizationUnit (OrganizationUnit.uid)
+  - name: identifier_type
+    type: string
+    description: AgentIdentifier type to test for, e.g. orcid, idref, idhals, scopus, hal, openalex, ror, wikidata, isni, viaf
+    default: orcid
+statement: |
+  MATCH (org:OrganizationUnit {uid: $organization_unit_uid})
+  OPTIONAL MATCH (person:Person)-[:MEMBER_OF]->(org)
+  WITH org, collect(DISTINCT person) AS all_members
+  WITH org, [m IN all_members WHERE m IS NOT NULL] AS members
+  WITH org, members,
+    [m IN members WHERE exists(
+      (m)-[:HAS_IDENTIFIER]->(:AgentIdentifier {type: $identifier_type}) )] AS with_id,
+    [m IN members WHERE NOT exists(
+      (m)-[:HAS_IDENTIFIER]->(:AgentIdentifier {type: $identifier_type}) )] AS without_id
+  RETURN
+    org.uid AS organization_unit_uid,
+    $identifier_type AS identifier_type,
+    size(members) AS member_count,
+    size(with_id) AS with_identifier_count,
+    size(without_id) AS without_identifier_count,
+    CASE WHEN size(members) = 0 THEN 0.0
+         ELSE round(100.0 * size(with_id) / size(members), 1) END AS percent_with_identifier,
+    [m IN with_id | {
+      person_uid: m.uid,
+      person_name: m.display_name,
+      identifier_values: [(m)-[:HAS_IDENTIFIER]->(i:AgentIdentifier {type: $identifier_type}) | i.value]
+    }] AS members_with_identifier,
+    [m IN without_id | {person_uid: m.uid, person_name: m.display_name}] AS members_without_identifier
+
+---
+
+kind: tool
 name: publications-by-theme
 type: neo4j-cypher
 source: crisalid-neo4j
@@ -634,6 +684,7 @@ tools:
   - search-researchers-by-concept
   - search-organization-unit-by-name
   - get-organization-unit-members
+  - count-organization-unit-members-with-identifier
   - publications-by-theme
 
 ---
@@ -654,5 +705,6 @@ tools:
   - search-researchers-by-concept
   - search-organization-unit-by-name
   - get-organization-unit-members
+  - count-organization-unit-members-with-identifier
   - publications-by-theme
   - execute-cypher-readonly

--- a/tests/test_mcp_toolbox_count_members_with_identifier.py
+++ b/tests/test_mcp_toolbox_count_members_with_identifier.py
@@ -1,0 +1,103 @@
+import json
+import pytest
+
+ORGANIZATION_UNIT_UID = "local-ru-123456"
+PERSON_UID = "local-jdurand@univ-domain.edu"
+PERSON_ORCID = "0000-0001-2345-6789"
+UNKNOWN_UID = "unknown-org-unit-uid"
+
+
+@pytest.fixture
+async def count_tool(toolbox_client):
+    tools = await toolbox_client.aload_toolset("crisalid-restricted")
+    return next(
+        t for t in tools if t.name == "count-organization-unit-members-with-identifier"
+    )
+
+
+def _row(result):
+    data = json.loads(result) if isinstance(result, str) else result
+    assert data, "Expected at least one result row"
+    return data[0]
+
+
+@pytest.mark.asyncio
+async def test_result_structure(count_tool):
+    result = await count_tool.ainvoke(
+        {"organization_unit_uid": ORGANIZATION_UNIT_UID, "identifier_type": "orcid"}
+    )
+    row = _row(result)
+    for key in (
+        "organization_unit_uid",
+        "identifier_type",
+        "member_count",
+        "with_identifier_count",
+        "without_identifier_count",
+        "percent_with_identifier",
+        "members_with_identifier",
+        "members_without_identifier",
+    ):
+        assert key in row, f"Expected key {key} in {row}"
+
+
+@pytest.mark.asyncio
+async def test_orcid_counts_are_consistent(count_tool):
+    result = await count_tool.ainvoke(
+        {"organization_unit_uid": ORGANIZATION_UNIT_UID, "identifier_type": "orcid"}
+    )
+    row = _row(result)
+    assert row["with_identifier_count"] + row["without_identifier_count"] == row["member_count"]
+    assert row["with_identifier_count"] == len(row["members_with_identifier"])
+    assert row["without_identifier_count"] == len(row["members_without_identifier"])
+
+
+@pytest.mark.asyncio
+async def test_percent_matches_counts(count_tool):
+    result = await count_tool.ainvoke(
+        {"organization_unit_uid": ORGANIZATION_UNIT_UID, "identifier_type": "orcid"}
+    )
+    row = _row(result)
+    expected = round(100.0 * row["with_identifier_count"] / row["member_count"], 1)
+    assert row["percent_with_identifier"] == pytest.approx(expected)
+
+
+@pytest.mark.asyncio
+async def test_member_with_orcid_is_listed_with_value(count_tool):
+    result = await count_tool.ainvoke(
+        {"organization_unit_uid": ORGANIZATION_UNIT_UID, "identifier_type": "orcid"}
+    )
+    row = _row(result)
+    by_uid = {m["person_uid"]: m for m in row["members_with_identifier"]}
+    assert PERSON_UID in by_uid, f"Expected {PERSON_UID} among ORCID holders"
+    assert PERSON_ORCID in by_uid[PERSON_UID]["identifier_values"]
+    assert by_uid[PERSON_UID]["person_name"], "Expected non-empty person_name"
+
+
+@pytest.mark.asyncio
+async def test_identifier_type_defaults_to_orcid(count_tool):
+    # identifier_type omitted -> defaults to 'orcid'
+    result = await count_tool.ainvoke({"organization_unit_uid": ORGANIZATION_UNIT_UID})
+    row = _row(result)
+    assert row["identifier_type"] == "orcid"
+    assert PERSON_UID in {m["person_uid"] for m in row["members_with_identifier"]}
+
+
+@pytest.mark.asyncio
+async def test_missing_identifier_type_puts_member_in_without_group(count_tool):
+    # No fixture member carries a 'scopus' identifier.
+    result = await count_tool.ainvoke(
+        {"organization_unit_uid": ORGANIZATION_UNIT_UID, "identifier_type": "scopus"}
+    )
+    row = _row(result)
+    assert row["with_identifier_count"] == 0
+    assert row["percent_with_identifier"] == 0.0
+    assert PERSON_UID in {m["person_uid"] for m in row["members_without_identifier"]}
+
+
+@pytest.mark.asyncio
+async def test_unknown_unit_returns_empty(count_tool):
+    result = await count_tool.ainvoke(
+        {"organization_unit_uid": UNKNOWN_UID, "identifier_type": "orcid"}
+    )
+    data = json.loads(result) if isinstance(result, str) else result
+    assert not data, "Expected empty result for unknown organization unit"

--- a/tests/test_mcp_toolbox_toolsets.py
+++ b/tests/test_mcp_toolbox_toolsets.py
@@ -5,11 +5,11 @@ import pytest
 async def test_restricted_toolset_tools(toolbox_client):
     tools = await toolbox_client.aload_toolset("crisalid-restricted")
     names = set(t.name for t in tools)
-    assert names == {"get-crisalid-schema", "list-person-publications", "get-publication", "list-person-concepts", "search-person-by-name", "list-person-collaborators", "get-institution-locations", "get-person-memberships", "search-researchers-by-concept", "search-organization-unit-by-name", "get-organization-unit-members", "publications-by-theme"}
+    assert names == {"get-crisalid-schema", "list-person-publications", "get-publication", "list-person-concepts", "search-person-by-name", "list-person-collaborators", "get-institution-locations", "get-person-memberships", "search-researchers-by-concept", "search-organization-unit-by-name", "get-organization-unit-members", "count-organization-unit-members-with-identifier", "publications-by-theme"}
 
 
 @pytest.mark.asyncio
 async def test_unrestricted_toolset_tools(toolbox_client):
     tools = await toolbox_client.aload_toolset("crisalid-unrestricted")
     names = set(t.name for t in tools)
-    assert names == {"get-crisalid-schema", "list-person-publications", "get-publication", "list-person-concepts", "search-person-by-name", "list-person-collaborators", "get-institution-locations", "get-person-memberships", "search-researchers-by-concept", "search-organization-unit-by-name", "get-organization-unit-members", "publications-by-theme", "execute-cypher-readonly"}
+    assert names == {"get-crisalid-schema", "list-person-publications", "get-publication", "list-person-concepts", "search-person-by-name", "list-person-collaborators", "get-institution-locations", "get-person-memberships", "search-researchers-by-concept", "search-organization-unit-by-name", "get-organization-unit-members", "count-organization-unit-members-with-identifier", "publications-by-theme", "execute-cypher-readonly"}


### PR DESCRIPTION
## Problem

Questions of the form *"what proportion of LS2N researchers have an ORCID?"* are currently unanswerable in a reliable way. The agent has to:

1. call `get-organization-unit-members` to get the member list (names + uids only — **no identifiers**), then
2. probe each member individually with `search-person-by-name` to discover their identifiers.

No LLM does step 2 exhaustively over a 298-member lab: it samples a handful and presents the sample as a total. Observed on the LS2N graph: the agent answered **~4.7 % (14/298)** with an inconsistent list (the count drifted 12 → 14 between runs and missed members it had itself just confirmed had an ORCID). The **true figure is 50.3 % (150/298)** — an order-of-magnitude error. The root cause is a missing aggregation tool, not the model.

## Change

Add a curated tool **`count-organization-unit-members-with-identifier`** that computes the whole thing in a single deterministic Cypher query, parameterised by `identifier_type` (default `orcid`, also `idref`, `idhals`, `scopus`, …):

Returns, for one `OrganizationUnit` UID:

- `member_count`, `with_identifier_count`, `without_identifier_count`
- `percent_with_identifier`
- `members_with_identifier` (uid, name, identifier values) and `members_without_identifier` (uid, name)

So a single call answers both *"what proportion …"* and *"which members have / don't have …"*. It only counts direct members (the `MEMBER_OF` relation from `Person` nodes), consistent with `get-organization-unit-members`.

## Validated against a live graph

Run verbatim against the production CRISalid graph (LS2N = `local-91321`):

| identifier_type | members | with | without | percent |
|---|---|---|---|---|
| orcid | 298 | 150 | 148 | 50.3 |
| idref | 298 | 234 | 64 | 78.5 |
| viaf | 298 | 0 | 298 | 0.0 |
| *(unknown unit uid)* | — | — | — | empty result |

## Notes for reviewers

- `tools.yaml` and `tools-auth.yaml` kept in sync (the auth version carries `authRequired: [crisalid-keycloak]`); tool registered in **both** `crisalid-restricted` and `crisalid-unrestricted` toolsets.
- Toolset assertion test updated; new test module `tests/test_mcp_toolbox_count_members_with_identifier.py` covers count consistency, the percentage, the with/without branches, the `orcid` default, and the unknown-unit empty result (uses the existing `local-ru-123456` fixture).
- `uv run ruff check .` passes.
- Suggested follow-up (separate, not in this PR): a system-prompt rule telling the agent to use this tool for proportion/count/list-by-identifier questions instead of looping over members.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
